### PR TITLE
Add doit task to generate json schema - was missing before.

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -28,6 +28,17 @@ def task_validate_schemas():
         "actions": [(data_model.validate_schemas, [])],
     }
 
+def task_generate_json_schemas():
+    """Generate JSON schemas"""
+    return {
+        "task_dep": [f"validate_schemas"],
+        "file_dep": [schema.file_path for schema in data_model.schemas]
+        + [schema.meta_schema_path for schema in data_model.schemas],
+        "targets": [schema.json_schema_path for schema in data_model.schemas],
+        "actions": [(data_model.generate_json_schemas, [])],
+        "clean": True,
+    }
+
 def task_validate_example_files():
     """Validates the example files against the JSON schema (and other validation steps)"""
     return {


### PR DESCRIPTION
Added a task to the dodo.py file to generate the json schema to validate against. This important step provides the actionable information to format the example files properly to be able to validate - for example, that required metadata properties are

> "required": [
> "schema_author",
> "schema_name", (not "schema")
> "schema_version",
> "author",
> "description",
> "time_of_creation"
